### PR TITLE
댓글, 대댓글 기능 수정

### DIFF
--- a/src/repositories/PostCommentRepository.ts
+++ b/src/repositories/PostCommentRepository.ts
@@ -5,10 +5,8 @@ import { PostComment } from "../entities/PostComment";
 export class PostCommentRepository extends Repository<PostComment> {
   public async getCommentById(postId: string, commentId: string) {
     return this.createQueryBuilder("comment")
-      .where("comment.postId = :postId AND comment.id = :commentId", {
-        postId,
-        commentId,
-      })
+      .where("comment.id = :commentId", { commentId })
+      .andWhere("comment.postId = :postId", { postId })
       .getOne();
   }
 
@@ -20,10 +18,11 @@ export class PostCommentRepository extends Repository<PostComment> {
         "comment.createdAt",
         "comment.postId",
         "comment.isReplies",
+        "comment.isDeleted",
       ])
       .leftJoinAndSelect("comment.user", "user")
       .where("comment.postId = :postId", { postId })
-      .andWhere("comment.depth = 0")
+      .andWhere("comment.depth = :value", { value: 0 })
       .orderBy("comment.createdAt", "ASC")
       .getMany();
   }
@@ -51,6 +50,7 @@ export class PostCommentRepository extends Repository<PostComment> {
         "comment.text",
         "comment.createdAt",
         "comment.postId",
+        "comment.isDeleted",
       ])
       .leftJoinAndSelect("comment.user", "user")
       .where("comment.postId = :postId", { postId })

--- a/src/repositories/PostCommentRepository.ts
+++ b/src/repositories/PostCommentRepository.ts
@@ -36,8 +36,8 @@ export class PostCommentRepository extends Repository<PostComment> {
         "comment.createdAt",
         "comment.postId",
       ])
-      .leftJoinAndSelect("comment.user", "user")
       .where("comment.userId = :userId", { userId })
+      .andWhere("comment.isDeleted = :value", { value: false })
       .orderBy("comment.createdAt", "DESC")
       .getMany();
   }

--- a/src/repositories/PostRepository.ts
+++ b/src/repositories/PostRepository.ts
@@ -62,7 +62,6 @@ export class PostRepository extends Repository<Post> {
         "post.view",
         "post.like",
       ])
-      .leftJoinAndSelect("post.user", "user")
       .where("post.userId = :userId", { userId })
       .orderBy("post.createdAt", "DESC")
       .getMany();

--- a/src/services/PostCommentService.ts
+++ b/src/services/PostCommentService.ts
@@ -52,8 +52,22 @@ export class PostCommentService {
     return await this.postCommentRepository.save(commentReply);
   }
 
-  public async getCommentByPostId(postId: string): Promise<PostComment[]> {
-    return await this.postCommentRepository.getCommentsByPostId(postId);
+  public async getCommentByPostId(postId: string) {
+    const count = await this.postCommentRepository.count({
+      where: {
+        postId: postId,
+        isDeleted: false,
+      },
+    });
+
+    const comments = await this.postCommentRepository.getCommentsByPostId(
+      postId,
+    );
+
+    return {
+      count,
+      comments,
+    };
   }
 
   public async getCommentReplies(
@@ -105,7 +119,9 @@ export class PostCommentService {
     );
 
     if (postCommentToDelete?.userId === userId) {
-      await this.postCommentRepository.delete({ id: commentId });
+      postCommentToDelete.text = "작성자에 의해 삭제된 댓글입니다.";
+      postCommentToDelete.isDeleted = true;
+      await this.postCommentRepository.save(postCommentToDelete);
       return true;
     }
 

--- a/test/e2e/api/posts.test.ts
+++ b/test/e2e/api/posts.test.ts
@@ -271,9 +271,10 @@ describe("GET /api/posts/:postId/comments", () => {
       .expect(200);
 
     const { body } = response;
-    expect(body[0].text).toBe("댓글 내용입니다.");
-    expect(body[0].postId).toBe(PostSeed[0].id);
-    testPostCommentId = body[0].id;
+    expect(body.count).toBe(1);
+    expect(body.comments[0].text).toBe("댓글 내용입니다.");
+    expect(body.comments[0].postId).toBe(PostSeed[0].id);
+    testPostCommentId = body.comments[0].id;
   });
 
   it("400: 해당하는 Post가 없어서 댓글 조회에 실패한다", async () => {

--- a/test/unit/services/PostCommentService.test.ts
+++ b/test/unit/services/PostCommentService.test.ts
@@ -78,16 +78,16 @@ describe("PostCommentService", () => {
     const postComments = await postCommentService.getCommentByPostId(
       request.postId,
     );
-    expect(postComments[0].isReplies).toBeTruthy();
+    expect(postComments.comments[0].isReplies).toBeTruthy();
   });
 
   it("포스트Id가 일치하는 포스트 댓글 목록을 반환한다", async () => {
     const postComments = await postCommentService.getCommentByPostId(
       request.postId,
     );
-    expect(postComments.length).toBe(1);
-    expect(postComments[0].text).toBe(request.text);
-    expect(postComments[0].user.id).toBe(request.userId);
+    expect(postComments.count).toBe(2);
+    expect(postComments.comments[0].text).toBe(request.text);
+    expect(postComments.comments[0].user.id).toBe(request.userId);
   });
 
   it("포스트 댓글 답글 목록을 반환한다", async () => {


### PR DESCRIPTION
## What is this PR? :mag:
댓글, 대댓글 기능 수정

## Changes :memo:
- 댓글 삭제와 대댓글 삭제를 물리적 삭제에서 논리적 삭제로 변경
- 게시글의 댓글 목록 반환 때, 총 댓글 갯수(댓글 + 답글) 반환하도록 수정
- 사용자가 작성한 게시글, 댓글을 반환할 때 유저 정보를 포함하지 않도록 수정

## Screenshot :camera:
[x]